### PR TITLE
Make `world_tick` faster by not checking all cells as neighbor candidates

### DIFF
--- a/lib/cell.ex
+++ b/lib/cell.ex
@@ -1,3 +1,3 @@
 defmodule Golex.Cell do
-  defstruct position: [], neighbors: 0, alive: false
+  defstruct position: {0, 0}, neighbors: 0, alive: false
 end

--- a/lib/golex.ex
+++ b/lib/golex.ex
@@ -15,6 +15,21 @@ defmodule Golex do
     end
   end
 
+  @doc "Narrow down the neighbor candidates"
+  def neighbor_candidates(cells, %Cell{position: {cx, cy}}) do
+    [
+      Map.get(cells, {cx - 1, cy}),
+      Map.get(cells, {cx + 1, cy}),
+      Map.get(cells, {cx, cy - 1}),
+      Map.get(cells, {cx, cy + 1}),
+      Map.get(cells, {cx - 1, cy - 1}),
+      Map.get(cells, {cx + 1, cy + 1}),
+      Map.get(cells, {cx - 1, cy + 1}),
+      Map.get(cells, {cx + 1, cy - 1})
+    ]
+    |> Enum.reject(&(&1 == nil))
+  end
+
   def neighbors([], _) do
     0
   end
@@ -29,7 +44,7 @@ defmodule Golex do
     end)
   end
 
-  defp neighbor?(%Cell{position: [cx, cy], alive: living}, [x, y]) do
+  defp neighbor?(%Cell{position: {cx, cy}, alive: living}, {x, y}) do
     cond do
       # Dead cells aren't counted as neighbors
       !living ->
@@ -57,9 +72,12 @@ defmodule Golex do
   end
 
   defp do_world_tick(cells) do
-    Enum.map(cells, fn cell ->
-      %Cell{cell | neighbors: neighbors(cells, cell)} |> cell_tick
+    Enum.map(cells, fn {pos, cell} ->
+      {pos,
+       %Cell{cell | neighbors: cells |> neighbor_candidates(cell) |> neighbors(cell)}
+       |> cell_tick()}
     end)
+    |> Enum.into(%{})
   end
 
   @doc """
@@ -69,7 +87,11 @@ defmodule Golex do
     xs = Enum.to_list(0..(width - 1))
     ys = Enum.to_list(0..(height - 1))
     cs = coords(xs, ys)
-    %World{dimensions: [width, height], cells: Enum.map(cs, fn {x, y} -> new_cell(x, y) end)}
+
+    %World{
+      dimensions: {width, height},
+      cells: Enum.map(cs, fn {x, y} -> {{x, y}, new_cell(x, y)} end) |> Enum.into(%{})
+    }
   end
 
   defp coords(xs, ys) do
@@ -84,7 +106,7 @@ defmodule Golex do
     - alive set to true or false randomly
   """
   def random_cell(max_x, max_y) do
-    %Cell{position: [rand(max_x), rand(max_y)], neighbors: rand(8), alive: rand(1) == 1}
+    %Cell{position: {rand(max_x), rand(max_y)}, neighbors: rand(8), alive: rand(1) == 1}
   end
 
   @doc """
@@ -94,25 +116,24 @@ defmodule Golex do
     - Alive set to true or false randomly
   """
   def new_cell(x, y) do
-    %Cell{position: [x, y], neighbors: rand(8), alive: rand(1) == 1}
+    %Cell{position: {x, y}, neighbors: rand(8), alive: rand(1) == 1}
   end
 
   defp rand(max) do
     :rand.uniform(max + 1) - 1
   end
 
-  def world_string(%World{cells: []}, acc) do
-    acc
+  def world_string(%World{dimensions: {w, h}, cells: cells}, []) do
+    xs = Enum.to_list(0..(w - 1))
+    ys = Enum.to_list(0..(h - 1))
+    cs = coords(xs, ys)
+
+    Enum.map(cs, fn pos ->
+      cell_string(w, Map.get(cells, pos))
+    end)
   end
 
-  def world_string(%World{dimensions: [w, he], cells: [h | t]}, acc) do
-    world_string(
-      %World{dimensions: [w, he], cells: t},
-      acc ++ [cell_string(w, h)]
-    )
-  end
-
-  defp cell_string(width, %Cell{position: [x, _], alive: living}) do
+  defp cell_string(width, %Cell{position: {x, _}, alive: living}) do
     cond do
       x + 1 == width && living -> "#\n"
       x + 1 == width && !living -> ".\n"

--- a/lib/world.ex
+++ b/lib/world.ex
@@ -1,3 +1,3 @@
 defmodule Golex.World do
-  defstruct dimensions: [], cells: []
+  defstruct dimensions: {0, 0}, cells: %{}
 end

--- a/test/golex_test.exs
+++ b/test/golex_test.exs
@@ -4,11 +4,11 @@ defmodule GolexTest do
   alias Golex.Cell
   alias Golex.World
 
-  @cell1 %Cell{position: [1, 1], neighbors: -1, alive: true}
-  @cell2 %Cell{position: [0, 1], neighbors: 2, alive: true}
-  @cell3 %Cell{position: [0, 0], neighbors: 4, alive: true}
-  @cell4 %Cell{position: [0, 2], neighbors: 3, alive: true}
-  @cell5 %Cell{position: [1, 0], neighbors: 0, alive: true}
+  @cell1 %Cell{position: {1, 1}, neighbors: -1, alive: true}
+  @cell2 %Cell{position: {0, 1}, neighbors: 2, alive: true}
+  @cell3 %Cell{position: {0, 0}, neighbors: 4, alive: true}
+  @cell4 %Cell{position: {0, 2}, neighbors: 3, alive: true}
+  @cell5 %Cell{position: {1, 0}, neighbors: 0, alive: true}
 
   test "Any live cell with fewer than two live neighbours dies, as if caused by under-population." do
     assert Golex.cell_tick(@cell1) ==
@@ -48,45 +48,60 @@ defmodule GolexTest do
   end
 
   test "World tick kills lonely cell" do
-    assert Golex.world_tick(%World{cells: [@cell2]}) ==
-             %World{cells: [%Cell{position: @cell2.position, neighbors: 0, alive: false}]}
+    # %Cell{position: @cell2.position, neighbors: 0, alive: false}
+    assert Golex.world_tick(%World{cells: %{@cell1.position => @cell2}}) == %Golex.World{
+             cells: %{
+               @cell1.position => %Golex.Cell{
+                 alive: false,
+                 neighbors: 0,
+                 position: @cell2.position
+               }
+             }
+           }
   end
 
   test "World tick kills crowded cells" do
-    w = %World{cells: [@cell3, @cell5, @cell2, @cell1, @cell4]}
+    w = %World{
+      cells: %{
+        @cell3.position => @cell3,
+        @cell5.position => @cell5,
+        @cell2.position => @cell2,
+        @cell1.position => @cell1,
+        @cell4.position => @cell4
+      }
+    }
 
-    assert Golex.world_tick(w) ==
-             %World{
-               cells: [
-                 %Cell{position: [0, 0], neighbors: 3, alive: true},
-                 %Cell{position: [1, 0], neighbors: 3, alive: true},
-                 %Cell{position: [0, 1], neighbors: 4, alive: false},
-                 %Cell{position: [1, 1], neighbors: 4, alive: false},
-                 %Cell{position: [0, 2], neighbors: 2, alive: true}
-               ]
+    assert Golex.world_tick(w) == %Golex.World{
+             cells: %{
+               {0, 0} => %Golex.Cell{alive: true, neighbors: 3, position: {0, 0}},
+               {0, 1} => %Golex.Cell{alive: false, neighbors: 4, position: {0, 1}},
+               {0, 2} => %Golex.Cell{alive: true, neighbors: 2, position: {0, 2}},
+               {1, 0} => %Golex.Cell{alive: true, neighbors: 3, position: {1, 0}},
+               {1, 1} => %Golex.Cell{alive: false, neighbors: 4, position: {1, 1}}
              }
+           }
   end
 
   test "Cells should die in world with few living neighbors" do
     w = %World{
-      cells: [
-        %Cell{@cell3 | alive: false},
-        %Cell{@cell5 | alive: false},
-        @cell2,
-        @cell1,
-        %Cell{@cell4 | alive: false}
-      ]
+      cells: %{
+        @cell3.position => %Cell{@cell3 | alive: false},
+        @cell5.position => %Cell{@cell5 | alive: false},
+        @cell2.position => @cell2,
+        @cell1.position => @cell1,
+        @cell4.position => %Cell{@cell4 | alive: false}
+      }
     }
 
     assert Golex.world_tick(w) ==
              %World{
-               cells: [
-                 %Cell{position: [0, 0], neighbors: 2, alive: false},
-                 %Cell{position: [1, 0], neighbors: 2, alive: false},
-                 %Cell{position: [0, 1], neighbors: 1, alive: false},
-                 %Cell{position: [1, 1], neighbors: 1, alive: false},
-                 %Cell{position: [0, 2], neighbors: 2, alive: false}
-               ]
+               cells: %{
+                 {0, 0} => %Cell{position: {0, 0}, neighbors: 2, alive: false},
+                 {1, 0} => %Cell{position: {1, 0}, neighbors: 2, alive: false},
+                 {0, 1} => %Cell{position: {0, 1}, neighbors: 1, alive: false},
+                 {1, 1} => %Cell{position: {1, 1}, neighbors: 1, alive: false},
+                 {0, 2} => %Cell{position: {0, 2}, neighbors: 2, alive: false}
+               }
              }
   end
 
@@ -104,17 +119,15 @@ defmodule GolexTest do
 
   test "Should get random, non empty, world" do
     w = Golex.random_world(80, 20)
-    assert length(w.cells) == 1600
-    assert hd(w.dimensions) == 80
-    assert Enum.at(w.dimensions, 1) == 20
+    assert Map.size(w.cells) == 1600
+    assert w.dimensions == {80, 20}
   end
 
   test "Should get random cell within bounds" do
     cs = Stream.repeatedly(fn -> Golex.random_cell(10, 10) end) |> Enum.take(10)
 
     Enum.each(cs, fn x ->
-      xp = hd(x.position)
-      yp = Enum.at(x.position, 1)
+      {xp, yp} = x.position
       assert xp >= 0
       assert xp <= 10
       assert yp >= 0
@@ -124,8 +137,7 @@ defmodule GolexTest do
 
   test "Should get new cell with specified position" do
     c = Golex.new_cell(1337, 42)
-    assert hd(c.position) == 1337
-    assert Enum.at(c.position, 1) == 42
+    assert {1337, 42} == c.position
   end
 
   test "Should have new line after each row" do


### PR DESCRIPTION
When coding golux (https://github.com/vorce/golux) I noticed
that updating the golex world was very slow (1+ second for a 80x60 world).
Calculating the new cell state was very naive; `O(n^2)` on the number of cells.
This should improve it to `O(n)` by storing the cells in a map instead of a list. 

Also changed cell positions and world dimensions to tuples instead of lists